### PR TITLE
Update to glutin 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ authors = ["Edwin Cheng <edwin0cheng@gmail.com>"]
 stdweb =  "0.4.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-glutin = "0.15.0"
+glutin = "0.17.0"
 time = "0.1.39"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub struct AppConfig {
     pub vsync: bool,
     pub headless: bool,
     pub fullscreen: bool,
+    pub resizable: bool,
     pub show_cursor: bool,
 }
 
@@ -48,8 +49,9 @@ impl AppConfig {
             size,
             vsync: true,
             headless: false,
-            show_cursor: true,
             fullscreen: false,
+            resizable: true,
+            show_cursor: true,
         }
     }
 }

--- a/src/native_app.rs
+++ b/src/native_app.rs
@@ -74,7 +74,7 @@ fn get_scan_code(input: glutin::KeyboardInput) -> String {
     translate_scan_code(input.scancode).into()
 }
 
-fn translate_event(e: glutin::Event) -> Option<AppEvent> {
+fn translate_event(e: glutin::Event, dpi_factor: f32) -> Option<AppEvent> {
     if let Event::WindowEvent {
         event: winevent, ..
     } = e
@@ -93,7 +93,10 @@ fn translate_event(e: glutin::Event) -> Option<AppEvent> {
                     ElementState::Released => Some(AppEvent::MouseUp(event)),
                 }
             }
-            WindowEvent::CursorMoved { position, .. } => Some(AppEvent::MousePos(position.into())),
+            WindowEvent::CursorMoved { position, .. } => {
+                let phys = glutin::dpi::PhysicalPosition::from_logical(position, f64::from(dpi_factor));
+                Some(AppEvent::MousePos(phys.into()))
+            },
             WindowEvent::KeyboardInput { input, .. } => match input.state {
                 ElementState::Pressed => Some(AppEvent::KeyDown(events::KeyDownEvent {
                     key: get_virtual_key(input),
@@ -110,7 +113,10 @@ fn translate_event(e: glutin::Event) -> Option<AppEvent> {
                     ctrl: input.modifiers.ctrl,
                 })),
             },
-            WindowEvent::Resized(size) => Some(AppEvent::Resized((size.width as u32, size.height as u32))),
+            WindowEvent::Resized(size) => {
+                let phys = glutin::dpi::PhysicalSize::from_logical(size, f64::from(dpi_factor));
+                Some(AppEvent::Resized(phys.into()))
+            },
 
             _ => None,
         }
@@ -143,14 +149,11 @@ impl App {
                 None
             };
 
-            let phys_size: glutin::dpi::PhysicalSize = (config.size.0, config.size.1).into();
-            let dpi = events_loop.get_primary_monitor().get_hidpi_factor();
-
             let window = glutin::WindowBuilder::new()
                 .with_title(config.title)
                 .with_fullscreen(monitor)
-                .with_resizable(false)
-                .with_dimensions(phys_size.to_logical(dpi));
+                .with_resizable(config.resizable)
+                .with_dimensions((config.size.0, config.size.1).into());
 
             let context = glutin::ContextBuilder::new()
                 .with_vsync(config.vsync)
@@ -218,6 +221,7 @@ impl App {
         use glutin::*;
         let mut running = true;
 
+        let dpi_factor = self.hidpi_factor();
         let (window, events_loop, events) = (&self.window, &mut self.events_loop, &mut self.events);
 
         events_loop.poll_events(|event| {
@@ -227,7 +231,7 @@ impl App {
                     &glutin::WindowEvent::Resized(size) => {
                         // Fixed for Windows which minimized to emit a Resized(0,0) event
                         if size.width != 0.0 && size.height != 0.0 {
-                            window.context().resize((size.width, size.height).into());
+                            window.window().resize(size.to_physical(dpi_factor as f64));
                         }
                     }
                     &glutin::WindowEvent::KeyboardInput { input, .. } => {
@@ -245,7 +249,8 @@ impl App {
                 },
                 _ => (),
             };
-            translate_event(event).map(|evt| events.borrow_mut().push(evt));
+
+            translate_event(event, dpi_factor).map(|evt| events.borrow_mut().push(evt));
         });
 
         return running;

--- a/src/native_keycode.rs
+++ b/src/native_keycode.rs
@@ -102,10 +102,9 @@ pub fn translate_virtual_key(c: VirtualKeyCode) -> &'static str {
         Grave => "Backquote",
         Kana => "",
         Kanji => "",
-        LAlt => "",
+        LAlt => "AltLeft",
         LBracket => "BracketLeft",
         LControl => "ControlLeft",
-        LMenu => "AltLeft",
         LShift => "ShiftLeft",
         LWin => "",
         Mail => "",
@@ -127,10 +126,9 @@ pub fn translate_virtual_key(c: VirtualKeyCode) -> &'static str {
         PlayPause => "",
         Power => "",
         PrevTrack => "",
-        RAlt => "",
+        RAlt => "AltRight",
         RBracket => "BracketRight",
         RControl => "ControlRight",
-        RMenu => "AltRight",
         RShift => "ShiftRight",
         RWin => "",
         Semicolon => "Semicolon",
@@ -154,6 +152,9 @@ pub fn translate_virtual_key(c: VirtualKeyCode) -> &'static str {
         WebStop => "",
         Yen => "",
         Caret => "Caret",
+        Copy => "Copy",
+        Paste => "Paste",
+        Cut => "Cut",
     }
 }
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
It doesn't compile without warnings, because of changes in the virtual
keycodes.

`LMenu` maps to `"AltLeft"` in `src/native_keycode.rs`, but this isn't defined by `glutin 0.17`. I assume the fix is simply mapping `LAlt` to `"AltLeft"` (ditto for `RMenu`) and adding the three missing patterns `Copy`, `Cut`, and `Paste`?

I would have already done this, but we currently map `LAlt` to `""`, so I'm quite confused as to the purpose of `LMenu` and `LAlt`.