### PR TITLE
app::print for native should use println to be more like console.log

### DIFF
--- a/src/native_app.rs
+++ b/src/native_app.rs
@@ -234,7 +234,7 @@ impl App {
 
     /// print a message on standard output (native) or js console (web)
     pub fn print<T: Into<String>>(msg: T) {
-        print!("{}", msg.into());
+        println!("{}", msg.into());
     }
 
     /// exit current process (close the game window). On web target, this does nothing.


### PR DESCRIPTION
App::print for web will log a separate line, but App::print for native will concat last logged item.  
This change uses println! instead of print! to make them more similar.
